### PR TITLE
Weight and height FileNotFoundError

### DIFF
--- a/src/testingprogram.py
+++ b/src/testingprogram.py
@@ -2,6 +2,7 @@ from torchvision import models, transforms
 import torch
 from PIL import Image
 import time
+import sys
 
 class TestingProgram:
     
@@ -108,8 +109,8 @@ class TestingProgram:
             self.height = int(heightFile.readline().strip())
             self.model.load_state_dict(torch.load(weightsFilePath, weights_only=True))
         except FileNotFoundError:
-            print("Model Weights File Does Not Exist. Run Testing Program")
-            return
+            print("Model Weights File or Height File Does Not Exist. Run Testing Program.")
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/testing/test_testingprogram.py
+++ b/testing/test_testingprogram.py
@@ -65,15 +65,15 @@ class TestUserChoice(unittest.TestCase):
 
 
     @patch('builtins.open', side_effect=FileNotFoundError)
-    @patch('sys.stdout', new_callable=StringIO)
-    def testLoadModelWeightsFileNotFoundMessage(self, mockStdout, mockOpen):
+    @patch('sys.exit')
+    def testLoadModelWeightsFileNotFoundMessage(self, mockSysExit, mockOpen):
         testingInstance = TestingProgram()
         
         # Call loadModelWeights with false file paths
-        testingInstance.loadModelWeights("nonexistent_weights.pth", "nonexistent_height.txt")
+        testingInstance.loadModelWeights("nonExistentWeights.pth", "nonExistentHeight.txt")
         
-        # Assert that the correct error message was printed
-        self.assertIn("Model Weights File Does Not Exist. Run Testing Program", mockStdout.getvalue())
+        # Assert that the system exits with 1
+        mockSysExit.assert_called_once_with(1)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Changed test for weight and height FileNotFoundError to check for system exit with a 1(error). Slightly tweaked how exception was handled in loadModelWeights method(changed return to sys.exit(1)).